### PR TITLE
Increased size of nbr in ServoPin_t to enable usage of alternative Pin Mappings

### DIFF
--- a/src/PRDC_ServoHT.h
+++ b/src/PRDC_ServoHT.h
@@ -41,7 +41,7 @@
 #define INVALID_SERVO 255
 
 typedef struct  {
-  uint8_t nbr;            // a pin number from 0 to 255
+  uint16_t nbr;            // 16 bit pin number to enable alternative pin mappings
   uint8_t isActive;       // true if this channel is enabled, pin not pulsed if false
   uint8_t prevAttached;       // true if this channel is previusly attached
 } ServoPin_t;


### PR DESCRIPTION
When using alternative Pin Mappings a Mask of 0xN00 is used to get the ALT_N mapping of a pin. This increases the pin number above 256. Therefore the uint8_t that is used in ServoPin_t is to small.

e.g. servo.attach(PB0 | 0x100) would fail, also the wrong pin number would be given to HardwareTimer.setMode() later.

This change has been tested on a Nucleo F446RE with the ALT_1 Mappings on Pins PA1(Timer5), PB0(Timer3), and PB8(Timer4).